### PR TITLE
Handle mobile login security and button

### DIFF
--- a/playground/src/views/_core/authentication/code-login.vue
+++ b/playground/src/views/_core/authentication/code-login.vue
@@ -2,12 +2,13 @@
 import type { VbenFormSchema } from '@vben/common-ui';
 import type { Recordable } from '@vben/types';
 
-import { computed, ref, useTemplateRef } from 'vue';
+import { computed, ref, useTemplateRef, markRaw } from 'vue';
 
-import { AuthenticationCodeLogin, z } from '@vben/common-ui';
+import { AuthenticationCodeLogin, SliderCaptcha, z } from '@vben/common-ui';
 import { $t } from '@vben/locales';
 
 import { message } from 'ant-design-vue';
+import { useAuthStore } from '#/store';
 
 defineOptions({ name: 'CodeLogin' });
 
@@ -49,6 +50,13 @@ const formSchema = computed((): VbenFormSchema[] => {
         }),
     },
     {
+      component: markRaw(SliderCaptcha),
+      fieldName: 'captcha',
+      rules: z.boolean().refine((value) => value, {
+        message: $t('authentication.verifyRequiredTip'),
+      }),
+    },
+    {
       component: 'VbenPinInput',
       componentProps: {
         codeLength: CODE_LENGTH,
@@ -60,8 +68,7 @@ const formSchema = computed((): VbenFormSchema[] => {
           return text;
         },
         handleSendCode: async () => {
-          // 模拟发送验证码
-          // Simulate sending verification code
+          // 模拟发送验证码，发送前校验手机号与验证码
           loading.value = true;
           const formApi = loginRef.value?.getFormApi();
           if (!formApi) {
@@ -69,10 +76,17 @@ const formSchema = computed((): VbenFormSchema[] => {
             throw new Error('formApi is not ready');
           }
           await formApi.validateField('phoneNumber');
+          await formApi.validateField('captcha');
           const isPhoneReady = await formApi.isFieldValid('phoneNumber');
+          const isCaptchaReady = await formApi.isFieldValid('captcha');
           if (!isPhoneReady) {
             loading.value = false;
             throw new Error('Phone number is not Ready');
+          }
+          if (!isCaptchaReady) {
+            loading.value = false;
+            message.error($t('authentication.verifyRequiredTip'));
+            throw new Error('Captcha is not passed');
           }
           const { phoneNumber } = await formApi.getValues();
           await sendCodeApi(phoneNumber);
@@ -94,8 +108,26 @@ const formSchema = computed((): VbenFormSchema[] => {
  * @param values 登录表单数据
  */
 async function handleLogin(values: Recordable<any>) {
-  // eslint-disable-next-line no-console
-  console.log(values);
+  const authStore = useAuthStore();
+  try {
+    loading.value = true;
+    // 简单校验验证码（演示用），真实项目请调用后端接口校验手机号+验证码
+    if (values.code !== '123456') {
+      message.error($t('authentication.codeTip', [CODE_LENGTH]));
+      throw new Error('Invalid verification code');
+    }
+    // 通过后，走统一登录流程（这里使用内置账号模拟）
+    await authStore.authLogin({ username: 'vben', password: '123456' });
+  } catch {
+    // 登陆失败，重置滑块验证
+    const formApi = loginRef.value?.getFormApi();
+    formApi?.setFieldValue('captcha', false, false);
+    formApi
+      ?.getFieldComponentRef<InstanceType<typeof SliderCaptcha>>('captcha')
+      ?.resume();
+  } finally {
+    loading.value = false;
+  }
 }
 </script>
 


### PR DESCRIPTION
## Description

This PR implements security and login handling for the mobile login page.

A `SliderCaptcha` component has been integrated into the form schema to gate the "Send Code" button, requiring users to complete the captcha before a verification code can be sent.

The `handleLogin` method is now fully implemented to validate the entered verification code (using a mock check for demonstration) and perform user authentication by integrating with the existing `authStore`. For improved user experience and security, the captcha is automatically reset upon any login failure, allowing users to retry.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs:dev` command.
- [ ] Run the tests with `pnpm test`.
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---
<a href="https://cursor.com/background-agent?bcId=bc-87ab1797-16b6-469f-8f6c-a8598a0be88a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87ab1797-16b6-469f-8f6c-a8598a0be88a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

